### PR TITLE
Adding "languages" path to load_plugin_textdomain argument.

### DIFF
--- a/wp-bitly.php
+++ b/wp-bitly.php
@@ -35,7 +35,7 @@ $wpbitly_options = wpbitly_get_options();
  * Load Plugin textdomain
  */
 function wpbitly_load_textdomain() {
-	load_plugin_textdomain( 'wpbitly', false, dirname( plugin_basename( __FILE__ ) ) ); 
+	load_plugin_textdomain( 'wpbitly', false, dirname( plugin_basename( __FILE__ ) ) . '/languages/'); 
 }
 // Load Plugin textdomain
 add_action( 'plugins_loaded', 'wpbitly_load_textdomain' );


### PR DESCRIPTION
The third argument of the textdomain function would need the directory name to locate mo language files.

I tested this change on my WordPress if it worked with Japanese mo file.
