### PR TITLE
Fixed Plugin Metabox Field Width 

### DIFF
--- a/wp-bitly-views.php
+++ b/wp-bitly-views.php
@@ -43,7 +43,7 @@ function wpbitly_build_metabox( $post, $args )
 	$shortlink = $args['args'][0];
 
 	echo '<label class="screen-reader-text" for="new-tag-post_tag">WP Bit.ly</label>';
-	echo '<p style="margin-top: 8px;"><input type="text" id="wpbitly-shortlink" name="_wpbitly" size="32" autocomplete="off" value="'.$shortlink.'" style="margin-right: 4px; color: #aaa;" /></p>';
+	echo '<p style="margin-top: 8px;"><input type="text" id="wpbitly-shortlink" name="_wpbitly" size="32" autocomplete="off" value="'.$shortlink.'" style="width: 100%;margin-right: 4px; color: #aaa;" /></p>';
 
 	$url = sprintf( $wpbitly->url['clicks'], $shortlink, $wpbitly->options['bitly_username'], $wpbitly->options['bitly_api_key'] );
 	$bitly_response = wpbitly_curl( $url );


### PR DESCRIPTION
The input-element at the plugin metabox was displayed much too wide, while using the new backend design, provided by the ["MP6"-plugin](http://wordpress.org/plugins/mp6/)

Setting the input-field to **width=100%** fixed it and causes no harm with the traditional backend.

![bitlyfix](https://f.cloud.github.com/assets/1038789/565903/66300712-c64b-11e2-845b-846fb38576d7.png)
